### PR TITLE
Stripe hardening, email flows, yearly pricing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+### 1. Plan Mode Default
+- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
+- If something goes sideways, STOP and re-plan immediately — don't keep pushing
+- Use plan mode for verification steps, not just building
+- Write detailed specs upfront to reduce ambiguity
+
+### 2. Subagent Strategy
+- Use subagents liberally to keep main context window clean
+- Offload research, exploration, and parallel analysis to subagents
+- For complex problems, throw more compute at it via subagents
+- One task per subagent for focused execution
+
+### 3. Self-Improvement Loop
+- After ANY correction from the user: update `tasks/lessons.md` with the pattern
+- Write rules for yourself that prevent the same mistake
+- Ruthlessly iterate on these lessons until mistake rate drops
+- Review lessons at session start for relevant project
+
+### 4. Verification Before Done
+- Never mark a task complete without proving it works
+- Diff behavior between main and your changes when relevant
+- Ask yourself: "Would a staff engineer approve this?"
+- Run tests, check logs, demonstrate correctness
+
+### 5. Demand Elegance (Balanced)
+- For non-trivial changes: pause and ask "is there a more elegant way?"
+- If a fix feels hacky: "Knowing everything I know now, implement the elegant solution"
+- Skip this for simple, obvious fixes — don't over-engineer
+- Challenge your own work before presenting it
+
+### 6. Autonomous Bug Fixing
+- When given a bug report: just fix it. Don't ask for hand-holding
+- Point at logs, errors, failing tests — then resolve them
+- Zero context switching required from the user
+- Go fix failing CI tests without being told how
+
+## Task Management
+
+1. **Plan First**: Write plan to `tasks/todo.md` with checkable items
+2. **Verify Plan**: Check in before starting implementation
+3. **Track Progress**: Mark items complete as you go
+4. **Explain Changes**: High-level summary at each step
+5. **Document Results**: Add review section to `tasks/todo.md`
+6. **Capture Lessons**: Update `tasks/lessons.md` after corrections
+
+## Core Principles
+
+- **Simplicity First**: Make every change as simple as possible. Impact minimal code.
+- **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
+- **Simplicity > Cleverness**
+- **Root Cause > Patch Fixes**
+- **Standards > Speed**

--- a/src/app/api/cron/trial-reminders/route.ts
+++ b/src/app/api/cron/trial-reminders/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { Resend } from "resend";
+import { buildTrialReminderEmail } from "@/lib/trial-reminder-email";
+
+export async function GET(req: NextRequest) {
+  // Verify cron authorization
+  const authHeader = req.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const resendKey = process.env.RESEND_API_KEY;
+
+  if (!supabaseUrl || !supabaseKey || !resendKey) {
+    return NextResponse.json({ error: "Missing configuration" }, { status: 503 });
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+  const resend = new Resend(resendKey);
+  const promoCode = process.env.TRIAL_REMINDER_PROMO_CODE || "EARLYADOPTER25";
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://www.doppelpod.io";
+
+  // Find trial users expiring within 2 days who haven't been reminded
+  const now = new Date();
+  const twoDaysFromNow = new Date(now.getTime() + 2 * 24 * 60 * 60 * 1000);
+
+  const { data: users, error } = await supabase
+    .from("profiles")
+    .select("id, email, trial_end")
+    .is("paid_tier", null)
+    .eq("email_confirmed", true)
+    .eq("trial_reminder_sent", false)
+    .not("trial_end", "is", null)
+    .gt("trial_end", now.toISOString())
+    .lte("trial_end", twoDaysFromNow.toISOString());
+
+  if (error) {
+    console.error("[trial-reminders] Query failed:", error.message);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+
+  let sent = 0;
+  for (const user of users || []) {
+    if (!user.email) continue;
+
+    const daysLeft = Math.max(1, Math.ceil(
+      (new Date(user.trial_end).getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
+    ));
+
+    try {
+      const { subject, html } = buildTrialReminderEmail(daysLeft, promoCode, `${baseUrl}/#pricing`);
+      await resend.emails.send({
+        from: "DoppelPod <noreply@doppelpod.io>",
+        to: user.email,
+        subject,
+        html,
+      });
+
+      await supabase
+        .from("profiles")
+        .update({ trial_reminder_sent: true })
+        .eq("id", user.id);
+
+      console.log(`[trial-reminders] Reminder sent to ${user.email} (${daysLeft} days left)`);
+      sent++;
+    } catch (err) {
+      console.error(`[trial-reminders] Failed for ${user.email}:`, err);
+    }
+  }
+
+  return NextResponse.json({ sent, total: users?.length || 0 });
+}

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,7 +1,43 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
+import Stripe from "stripe";
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import { Resend } from "resend";
 import { buildWelcomeEmail } from "@/lib/welcome-email";
+import { buildPaymentFailedEmail } from "@/lib/payment-failed-email";
+import { buildActionRequiredEmail } from "@/lib/action-required-email";
+
+function getSupabaseAdmin(): SupabaseClient | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key);
+}
+
+async function getEmailByCustomerId(supabase: SupabaseClient, customerId: string): Promise<string | null> {
+  const { data } = await supabase
+    .from("profiles")
+    .select("email")
+    .eq("stripe_customer_id", customerId)
+    .single();
+  return data?.email ?? null;
+}
+
+async function sendEmail(to: string, template: { subject: string; html: string }) {
+  const resendKey = process.env.RESEND_API_KEY;
+  if (!resendKey) return;
+  try {
+    const resend = new Resend(resendKey);
+    await resend.emails.send({
+      from: "DoppelPod <noreply@doppelpod.io>",
+      to,
+      subject: template.subject,
+      html: template.html,
+    });
+    console.log(`[stripe-webhook] Email sent to ${to}: ${template.subject}`);
+  } catch (err) {
+    console.error(`[stripe-webhook] Email failed for ${to}:`, err);
+  }
+}
 
 export async function POST(req: NextRequest) {
   const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
@@ -19,61 +55,78 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "No signature" }, { status: 400 });
   }
 
-  // Verify webhook signature using Stripe API
-  let event: { type: string; data: { object: Record<string, unknown> } };
+  // Verify webhook signature
+  const stripe = new Stripe(stripeKey);
+  let event: Stripe.Event;
   try {
-    const verifyRes = await fetch("https://api.stripe.com/v1/webhook_endpoints", {
-      headers: { Authorization: `Bearer ${stripeKey}` },
-    });
-    // For simplicity, parse the event directly — in production use stripe SDK for signature verification
-    event = JSON.parse(body);
-    console.log("[stripe-webhook] Event received:", event.type);
-  } catch {
-    console.error("[stripe-webhook] Failed to parse webhook body");
-    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+    event = stripe.webhooks.constructEvent(body, signature, webhookSecret);
+    console.log("[stripe-webhook] Event verified:", event.type);
+  } catch (err) {
+    console.error("[stripe-webhook] Signature verification failed:", err);
+    return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
   }
 
+  const supabase = getSupabaseAdmin();
+  if (!supabase) {
+    console.error("[stripe-webhook] Supabase not configured");
+    return NextResponse.json({ error: "Database not configured" }, { status: 503 });
+  }
+
+  // --- checkout.session.completed ---
   if (event.type === "checkout.session.completed") {
-    const session = event.data.object;
-    const customerEmail = session.customer_email as string | undefined;
-    const tier = (session.metadata as Record<string, string>)?.tier?.toLowerCase();
+    const session = event.data.object as Stripe.Checkout.Session;
+    const customerEmail = session.customer_email;
+    const tier = session.metadata?.tier?.toLowerCase();
+    const customerId = typeof session.customer === "string" ? session.customer : session.customer?.id;
 
     if (customerEmail && tier) {
-      // Update user tier in Supabase
-      const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-      const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+      // Update paid_tier and store stripe_customer_id
+      const updates: Record<string, unknown> = { paid_tier: tier };
+      if (customerId) updates.stripe_customer_id = customerId;
 
-      if (supabaseUrl && supabaseKey) {
-        const supabase = createClient(supabaseUrl, supabaseKey);
-        const { error } = await supabase
-          .from("profiles")
-          .update({ paid_tier: tier })
-          .eq("email", customerEmail);
+      const { error } = await supabase
+        .from("profiles")
+        .update(updates)
+        .eq("email", customerEmail);
 
-        if (error) {
-          console.error("[stripe-webhook] Supabase update failed:", error.message);
-        } else {
-          console.log(`[stripe-webhook] Updated ${customerEmail} paid_tier to: ${tier}`);
-
-          // Send welcome email
-          const resendKey = process.env.RESEND_API_KEY;
-          if (resendKey) {
-            try {
-              const resend = new Resend(resendKey);
-              const { subject, html } = buildWelcomeEmail(tier);
-              await resend.emails.send({
-                from: "DoppelPod <noreply@doppelpod.io>",
-                to: customerEmail,
-                subject,
-                html,
-              });
-              console.log(`[stripe-webhook] Welcome email sent to ${customerEmail}`);
-            } catch (emailErr) {
-              console.error("[stripe-webhook] Welcome email failed:", emailErr);
-            }
-          }
-        }
+      if (error) {
+        console.error("[stripe-webhook] Supabase update failed:", error.message);
+      } else {
+        console.log(`[stripe-webhook] Updated ${customerEmail} paid_tier to: ${tier}`);
+        await sendEmail(customerEmail, buildWelcomeEmail(tier));
       }
+    }
+  }
+
+  // --- invoice.payment_failed ---
+  if (event.type === "invoice.payment_failed") {
+    const invoice = event.data.object as Stripe.Invoice;
+    let email = invoice.customer_email;
+    const customerId = typeof invoice.customer === "string" ? invoice.customer : invoice.customer?.id;
+
+    if (!email && customerId) {
+      email = await getEmailByCustomerId(supabase, customerId);
+    }
+
+    if (email) {
+      const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://www.doppelpod.io";
+      await sendEmail(email, buildPaymentFailedEmail(`${baseUrl}/dashboard`));
+    }
+  }
+
+  // --- invoice.payment_action_required (3D Secure) ---
+  if (event.type === "invoice.payment_action_required") {
+    const invoice = event.data.object as Stripe.Invoice;
+    let email = invoice.customer_email;
+    const customerId = typeof invoice.customer === "string" ? invoice.customer : invoice.customer?.id;
+    const hostedUrl = invoice.hosted_invoice_url;
+
+    if (!email && customerId) {
+      email = await getEmailByCustomerId(supabase, customerId);
+    }
+
+    if (email && hostedUrl) {
+      await sendEmail(email, buildActionRequiredEmail(hostedUrl));
     }
   }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,6 +53,7 @@ const pricing = [
   {
     tier: "Trial",
     price: "Free",
+    yearlyTotal: null,
     period: "10 days",
     description: "Full Elite access — no credit card required",
     features: [
@@ -63,12 +64,13 @@ const pricing = [
       "All Elite features for 10 days",
     ],
     cta: "Start 10-Day Elite Trial",
-    highlighted: false,
+    highlight: null,
     isTrial: true,
   },
   {
     tier: "Pro",
     price: "$29",
+    yearlyTotal: "$290",
     period: "/mo",
     description: "For serious creators and founders",
     features: [
@@ -80,12 +82,13 @@ const pricing = [
       "Priority support",
     ],
     cta: "Go Pro",
-    highlighted: true,
+    highlight: "pro",
     isTrial: false,
   },
   {
     tier: "Elite",
     price: "$69",
+    yearlyTotal: "$690",
     period: "/mo",
     description: "Full autopilot for power users",
     features: [
@@ -97,7 +100,7 @@ const pricing = [
       "Dedicated account manager",
     ],
     cta: "Go Elite",
-    highlighted: false,
+    highlight: "elite",
     isTrial: false,
   },
 ];
@@ -120,14 +123,16 @@ export default function Home() {
   const [checkoutOpen, setCheckoutOpen] = useState(false);
   const [signupOpen, setSignupOpen] = useState(false);
   const [feedbackOpen, setFeedbackOpen] = useState(false);
-  const [checkoutTier, setCheckoutTier] = useState<{ tier: string; price: string; features: string[] }>({ tier: "", price: "", features: [] });
+  const [checkoutTier, setCheckoutTier] = useState<{ tier: string; price: string; features: string[]; billingPeriod: "monthly" | "yearly" }>({ tier: "", price: "", features: [], billingPeriod: "monthly" });
   const [activePlan, setActivePlan] = useState<string | null>(null);
-  const pendingCheckout = useRef<{ tier: string; price: string; features: string[] } | null>(null);
+  const [billingPeriod, setBillingPeriod] = useState<"monthly" | "yearly">("monthly");
+  const pendingCheckout = useRef<{ tier: string; price: string; features: string[]; billingPeriod: "monthly" | "yearly" } | null>(null);
 
   // Auto-open checkout after signup if user clicked a paid plan while unauthenticated
   useEffect(() => {
     if (user && pendingCheckout.current) {
       setCheckoutTier(pendingCheckout.current);
+      setBillingPeriod(pendingCheckout.current.billingPeriod);
       setCheckoutOpen(true);
       pendingCheckout.current = null;
     }
@@ -312,6 +317,29 @@ export default function Home() {
             <p className="mt-3 text-sm text-muted-foreground sm:mt-4 sm:text-base">
               Try for free. Scale when you&apos;re ready.
             </p>
+            <p className="mt-2 text-xs text-green-400">
+              Go yearly and get 2 months free.
+            </p>
+            <div className="mt-4 flex items-center justify-center gap-3">
+              <span className={`text-sm font-medium transition-colors ${billingPeriod === "monthly" ? "text-foreground" : "text-muted-foreground"}`}>
+                Monthly
+              </span>
+              <button
+                onClick={() => setBillingPeriod(billingPeriod === "monthly" ? "yearly" : "monthly")}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                  billingPeriod === "yearly" ? "bg-gradient-to-r from-purple-600 to-pink-600" : "bg-muted-foreground/30"
+                }`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${
+                    billingPeriod === "yearly" ? "translate-x-6" : "translate-x-1"
+                  }`}
+                />
+              </button>
+              <span className={`text-sm font-medium transition-colors ${billingPeriod === "yearly" ? "text-foreground" : "text-muted-foreground"}`}>
+                Yearly
+              </span>
+            </div>
           </motion.div>
           <div className="grid gap-4 sm:grid-cols-3 sm:gap-6">
             {pricing.map((plan, i) => (
@@ -325,12 +353,14 @@ export default function Home() {
               >
                 <Card
                   className={`relative overflow-visible h-full transition-all duration-200 hover:scale-105 hover:shadow-lg hover:shadow-purple-500/10 ${
-                    plan.highlighted
+                    plan.highlight === "pro"
                       ? "border-purple-500 bg-gradient-to-b from-purple-950/30 to-card shadow-lg shadow-purple-500/10"
-                      : "border-border/50 bg-card/50"
+                      : plan.highlight === "elite"
+                        ? "border-amber-500/60 bg-gradient-to-b from-amber-950/30 to-card shadow-lg shadow-amber-500/15"
+                        : "border-border/50 bg-card/50"
                   }`}
                 >
-                  {plan.highlighted && (
+                  {plan.highlight === "pro" && (
                     <div className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-gradient-to-r from-purple-600 to-pink-600 px-4 py-1 text-xs font-medium text-white">
                       Most Popular
                     </div>
@@ -339,9 +369,9 @@ export default function Home() {
                     <CardTitle className="text-lg sm:text-xl">{plan.tier}</CardTitle>
                     <CardDescription>{plan.description}</CardDescription>
                     <p className="text-2xl font-bold sm:text-3xl">
-                      {plan.price}
+                      {billingPeriod === "yearly" && plan.yearlyTotal ? plan.yearlyTotal : plan.price}
                       <span className="text-sm font-normal text-muted-foreground sm:text-base">
-                        {plan.period}
+                        {billingPeriod === "yearly" && plan.yearlyTotal ? "/year" : plan.period}
                       </span>
                     </p>
                   </CardHeader>
@@ -364,22 +394,25 @@ export default function Home() {
                     ) : (
                       <Button
                         className={`w-full transition-all duration-200 hover:scale-105 hover:shadow-lg ${
-                          plan.highlighted
+                          plan.highlight === "pro"
                             ? "bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white border-0 hover:shadow-purple-500/30"
-                            : ""
+                            : plan.highlight === "elite"
+                              ? "bg-gradient-to-r from-amber-600 to-yellow-500 hover:from-amber-700 hover:to-yellow-600 text-white border-0 hover:shadow-amber-500/30"
+                              : ""
                         }`}
-                        variant={plan.highlighted ? "default" : "outline"}
+                        variant={plan.highlight ? "default" : "outline"}
                         onClick={() => {
                           if (plan.isTrial) {
                             setSignupOpen(true);
                             return;
                           }
+                          const displayPrice = billingPeriod === "yearly" && plan.yearlyTotal ? plan.yearlyTotal : plan.price;
                           if (!user) {
-                            pendingCheckout.current = { tier: plan.tier, price: plan.price, features: plan.features };
+                            pendingCheckout.current = { tier: plan.tier, price: displayPrice, features: plan.features, billingPeriod };
                             setSignupOpen(true);
                             return;
                           }
-                          setCheckoutTier({ tier: plan.tier, price: plan.price, features: plan.features });
+                          setCheckoutTier({ tier: plan.tier, price: displayPrice, features: plan.features, billingPeriod });
                           setCheckoutOpen(true);
                         }}
                       >
@@ -558,6 +591,7 @@ export default function Home() {
         onOpenChange={setCheckoutOpen}
         tier={checkoutTier.tier}
         price={checkoutTier.price}
+        billingPeriod={checkoutTier.billingPeriod}
         features={checkoutTier.features}
         onSuccess={(tier) => {
           setActivePlan(tier);

--- a/src/components/checkout-modal.tsx
+++ b/src/components/checkout-modal.tsx
@@ -16,6 +16,7 @@ interface CheckoutModalProps {
   onOpenChange: (open: boolean) => void;
   tier: string;
   price: string;
+  billingPeriod: "monthly" | "yearly";
   features: string[];
   onSuccess: (tier: string) => void;
 }
@@ -25,6 +26,7 @@ export function CheckoutModal({
   onOpenChange,
   tier,
   price,
+  billingPeriod,
   features,
   onSuccess,
 }: CheckoutModalProps) {
@@ -32,10 +34,15 @@ export function CheckoutModal({
   const [errorMsg, setErrorMsg] = useState("");
 
   // Map tiers to Stripe price IDs (set real IDs in production)
-  const priceIds: Record<string, string> = {
+  const monthlyPriceIds: Record<string, string> = {
     Pro: process.env.NEXT_PUBLIC_STRIPE_PRO_PRICE_ID || "price_pro_placeholder",
     Elite: process.env.NEXT_PUBLIC_STRIPE_ELITE_PRICE_ID || "price_elite_placeholder",
   };
+  const yearlyPriceIds: Record<string, string> = {
+    Pro: process.env.NEXT_PUBLIC_STRIPE_YEARLY_PRO_PRICE_ID || "price_yearly_pro_placeholder",
+    Elite: process.env.NEXT_PUBLIC_STRIPE_YEARLY_ELITE_PRICE_ID || "price_yearly_elite_placeholder",
+  };
+  const priceIds = billingPeriod === "yearly" ? yearlyPriceIds : monthlyPriceIds;
 
   async function handleCheckout() {
     setStatus("loading");
@@ -85,7 +92,7 @@ export function CheckoutModal({
           <DialogTitle className="flex items-center gap-2">
             Upgrade to {tier}
             <span className="rounded-full bg-gradient-to-r from-purple-600 to-pink-600 px-2 py-0.5 text-[10px] font-medium text-white">
-              {price}/mo
+              {price}{billingPeriod === "yearly" ? "/yr" : "/mo"}
             </span>
           </DialogTitle>
           <DialogDescription>
@@ -160,11 +167,13 @@ export function CheckoutModal({
               <div className="flex items-center justify-between rounded-lg border border-border/50 bg-muted/30 px-4 py-3">
                 <div>
                   <p className="text-sm font-medium">{tier} Plan</p>
-                  <p className="text-[10px] text-muted-foreground">Billed monthly, cancel anytime</p>
+                  <p className="text-[10px] text-muted-foreground">
+                    {billingPeriod === "yearly" ? "Billed yearly, cancel anytime" : "Billed monthly, cancel anytime"}
+                  </p>
                 </div>
                 <p className="text-xl font-bold">
                   {price}
-                  <span className="text-xs font-normal text-muted-foreground">/mo</span>
+                  <span className="text-xs font-normal text-muted-foreground">{billingPeriod === "yearly" ? "/yr" : "/mo"}</span>
                 </p>
               </div>
 
@@ -194,7 +203,7 @@ export function CheckoutModal({
                     Processing...
                   </span>
                 ) : (
-                  `Subscribe to ${tier} — ${price}/mo`
+                  `Subscribe to ${tier} — ${price}${billingPeriod === "yearly" ? "/yr" : "/mo"}`
                 )}
               </Button>
               <button

--- a/src/components/dashboard-client.tsx
+++ b/src/components/dashboard-client.tsx
@@ -724,6 +724,7 @@ export function DashboardClient({
         onOpenChange={setCheckoutOpen}
         tier={checkoutTier}
         price={tierInfo[checkoutTier].price}
+        billingPeriod="monthly"
         features={tierInfo[checkoutTier].features}
         onSuccess={(tier) => setActivePlan(tier)}
       />

--- a/src/lib/action-required-email.ts
+++ b/src/lib/action-required-email.ts
@@ -1,0 +1,31 @@
+export function buildActionRequiredEmail(hostedInvoiceUrl: string) {
+  const html = `
+<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:560px;margin:0 auto;padding:40px 24px;color:#f0f0f0;background:#0a0a0a;">
+  <div style="margin-bottom:32px;">
+    <span style="font-size:24px;font-weight:700;background:linear-gradient(135deg,#9333ea,#ec4899);-webkit-background-clip:text;-webkit-text-fill-color:transparent;">DoppelPod</span>
+  </div>
+
+  <p style="font-size:16px;line-height:1.6;color:#e2e2e2;">Hey,</p>
+
+  <p style="font-size:16px;line-height:1.6;color:#e2e2e2;">
+    Your bank requires additional verification to process your DoppelPod payment. This usually takes less than a minute.
+  </p>
+
+  <div style="text-align:center;margin:32px 0;">
+    <a href="${hostedInvoiceUrl}" style="display:inline-block;padding:14px 36px;background:linear-gradient(135deg,#9333ea,#ec4899);color:#fff;font-size:15px;font-weight:600;text-decoration:none;border-radius:8px;">Complete Payment</a>
+  </div>
+
+  <p style="font-size:13px;line-height:1.6;color:#888;">
+    Your bank may ask you to confirm the charge via your banking app or a text message. Once confirmed, your subscription continues as normal.
+  </p>
+
+  <div style="margin-top:48px;padding-top:24px;border-top:1px solid rgba(255,255,255,0.08);font-size:11px;color:#666;">
+    <p style="margin:0;">DoppelPod by Hapawire LLC</p>
+  </div>
+</div>`;
+
+  return {
+    subject: "Action required: Complete your DoppelPod payment",
+    html,
+  };
+}

--- a/src/lib/payment-failed-email.ts
+++ b/src/lib/payment-failed-email.ts
@@ -1,0 +1,35 @@
+export function buildPaymentFailedEmail(dashboardUrl: string) {
+  const html = `
+<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:560px;margin:0 auto;padding:40px 24px;color:#f0f0f0;background:#0a0a0a;">
+  <div style="margin-bottom:32px;">
+    <span style="font-size:24px;font-weight:700;background:linear-gradient(135deg,#9333ea,#ec4899);-webkit-background-clip:text;-webkit-text-fill-color:transparent;">DoppelPod</span>
+  </div>
+
+  <p style="font-size:16px;line-height:1.6;color:#e2e2e2;">Hey,</p>
+
+  <p style="font-size:16px;line-height:1.6;color:#e2e2e2;">
+    We weren't able to process your latest payment. This usually means your card was declined or has expired.
+  </p>
+
+  <p style="font-size:16px;line-height:1.6;color:#e2e2e2;">
+    To keep your DoppelPod subscription active, please update your payment method.
+  </p>
+
+  <div style="text-align:center;margin:32px 0;">
+    <a href="${dashboardUrl}" style="display:inline-block;padding:14px 36px;background:linear-gradient(135deg,#9333ea,#ec4899);color:#fff;font-size:15px;font-weight:600;text-decoration:none;border-radius:8px;">Update Payment Method</a>
+  </div>
+
+  <p style="font-size:13px;line-height:1.6;color:#888;">
+    If you don't update your payment method, your subscription will be paused and you'll lose access to your features.
+  </p>
+
+  <div style="margin-top:48px;padding-top:24px;border-top:1px solid rgba(255,255,255,0.08);font-size:11px;color:#666;">
+    <p style="margin:0;">DoppelPod by Hapawire LLC</p>
+  </div>
+</div>`;
+
+  return {
+    subject: "Payment failed — update your DoppelPod billing",
+    html,
+  };
+}

--- a/src/lib/trial-reminder-email.ts
+++ b/src/lib/trial-reminder-email.ts
@@ -1,0 +1,40 @@
+export function buildTrialReminderEmail(daysLeft: number, promoCode: string, pricingUrl: string) {
+  const html = `
+<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:560px;margin:0 auto;padding:40px 24px;color:#f0f0f0;background:#0a0a0a;">
+  <div style="margin-bottom:32px;">
+    <span style="font-size:24px;font-weight:700;background:linear-gradient(135deg,#9333ea,#ec4899);-webkit-background-clip:text;-webkit-text-fill-color:transparent;">DoppelPod</span>
+  </div>
+
+  <p style="font-size:16px;line-height:1.6;color:#e2e2e2;">Hey,</p>
+
+  <p style="font-size:16px;line-height:1.6;color:#e2e2e2;">
+    Your DoppelPod Elite trial ends in <strong style="color:#c084fc;">${daysLeft} day${daysLeft !== 1 ? "s" : ""}</strong>.
+  </p>
+
+  <p style="font-size:16px;line-height:1.6;color:#e2e2e2;">
+    You've had full access to voice cloning, video avatars, Claude Cowork, and priority rendering. To keep everything unlocked, subscribe now and get <strong style="color:#22c55e;">25% off your first month</strong>.
+  </p>
+
+  <div style="margin:24px 0;padding:16px 20px;border-radius:12px;border:1px solid rgba(34,197,94,0.3);background:rgba(34,197,94,0.08);text-align:center;">
+    <p style="margin:0 0 4px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:1px;color:#22c55e;">Your promo code</p>
+    <p style="margin:0;font-size:24px;font-weight:700;color:#22c55e;letter-spacing:2px;">${promoCode}</p>
+  </div>
+
+  <div style="text-align:center;margin:32px 0;">
+    <a href="${pricingUrl}" style="display:inline-block;padding:14px 36px;background:linear-gradient(135deg,#9333ea,#ec4899);color:#fff;font-size:15px;font-weight:600;text-decoration:none;border-radius:8px;">Choose a Plan</a>
+  </div>
+
+  <p style="font-size:13px;line-height:1.6;color:#888;">
+    After your trial ends, you'll lose access to voice cloning, video avatars, Claude Cowork, and data export. Your account and past generations will be saved.
+  </p>
+
+  <div style="margin-top:48px;padding-top:24px;border-top:1px solid rgba(255,255,255,0.08);font-size:11px;color:#666;">
+    <p style="margin:0;">DoppelPod by Hapawire LLC</p>
+  </div>
+</div>`;
+
+  return {
+    subject: `Your DoppelPod trial ends in ${daysLeft} day${daysLeft !== 1 ? "s" : ""} — here's 25% off`,
+    html,
+  };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/trial-reminders",
+      "schedule": "0 14 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Stripe webhook rewritten with proper signature verification + service role key (bypasses RLS)
- Handles checkout.session.completed, invoice.payment_failed, invoice.payment_action_required
- Payment-failed, 3D Secure action-required, and trial-reminder email templates via Resend
- Vercel cron sends 25% off reminder 2 days before trial expiry
- Monthly/yearly pricing toggle with annual totals and 2 months free messaging
- Elite card gold/amber styling; CheckoutModal routes to yearly Stripe price IDs

## Test plan
- [ ] Stripe test webhook fires on checkout, payment failure, and 3D Secure events
- [ ] Trial reminder cron sends email and marks trial_reminder_sent = true
- [ ] Yearly toggle shows correct annual prices and routes to yearly price IDs at checkout
- [ ] Payment-failed and action-required emails render correctly

Generated with [Claude Code](https://claude.com/claude-code)
