### PR TITLE
Fix photo avatar video, voice cloning coming soon

### DIFF
--- a/src/app/api/generate-video/route.ts
+++ b/src/app/api/generate-video/route.ts
@@ -40,36 +40,30 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // If user uploaded a photo, create an instant avatar first
-    let avatarId: string | undefined;
+    // If user uploaded a photo, upload it as an asset for a talking photo
+    let talkingPhotoId: string | undefined;
     if (avatarPhoto && avatarPhoto.size > 0) {
-      console.log("[generate-video] Creating instant avatar from uploaded photo...");
+      console.log("[generate-video] Uploading photo asset for talking photo...");
       const photoBuffer = Buffer.from(await avatarPhoto.arrayBuffer());
-      const photoFormData = new FormData();
-      photoFormData.append(
-        "image",
-        new Blob([photoBuffer], { type: avatarPhoto.type }),
-        avatarPhoto.name
-      );
 
-      const avatarRes = await fetch(
-        "https://api.heygen.com/v1/photo_avatar.create",
-        {
-          method: "POST",
-          headers: { "X-Api-Key": apiKey },
-          body: photoFormData,
-        }
-      );
+      const assetRes = await fetch("https://upload.heygen.com/v1/asset", {
+        method: "POST",
+        headers: {
+          "X-Api-Key": apiKey,
+          "Content-Type": avatarPhoto.type,
+        },
+        body: photoBuffer,
+      });
 
-      if (avatarRes.ok) {
-        const avatarData = await avatarRes.json();
-        avatarId = avatarData.data?.photo_avatar_id;
-        console.log("[generate-video] Created avatar:", avatarId);
+      if (assetRes.ok) {
+        const assetData = await assetRes.json();
+        talkingPhotoId = assetData.data?.url;
+        console.log("[generate-video] Photo asset uploaded:", talkingPhotoId);
       } else {
-        const errBody = await avatarRes.text().catch(() => "");
+        const errBody = await assetRes.text().catch(() => "");
         console.warn(
-          "[generate-video] Avatar creation failed, using default. Status:",
-          avatarRes.status,
+          "[generate-video] Photo upload failed, using default avatar. Status:",
+          assetRes.status,
           errBody
         );
       }
@@ -137,8 +131,8 @@ export async function POST(req: NextRequest) {
     const videoPayload: Record<string, unknown> = {
       video_inputs: [
         {
-          character: avatarId
-            ? { type: "photo_avatar", photo_avatar_id: avatarId }
+          character: talkingPhotoId
+            ? { type: "talking_photo", talking_photo_id: talkingPhotoId }
             : {
                 type: "avatar",
                 avatar_id: "Daisy-inskirt-20220818",

--- a/src/components/dashboard-client.tsx
+++ b/src/components/dashboard-client.tsx
@@ -615,44 +615,16 @@ export function DashboardClient({
             </CardHeader>
             <CardContent className="space-y-4">
               <p className="text-sm text-muted-foreground">
-                Upload a voice sample (30s–2min) to create your AI voice clone.
+                Upload a voice sample to train your AI voice clone.
               </p>
-              <div className="flex flex-wrap items-center gap-3">
-                <input
-                  ref={fileRef}
-                  type="file"
-                  accept="audio/*"
-                  className="hidden"
-                  onChange={handleVoiceUpload}
-                />
-                <Button
-                  variant="outline"
-                  className="border-purple-500/30 text-purple-300 hover:bg-purple-500/10"
-                  onClick={() => fileRef.current?.click()}
-                  disabled={voiceUploading}
-                >
-                  {voiceUploading ? "Uploading..." : "Upload Voice Sample"}
-                </Button>
-                {voiceStatus && (
-                  <span
-                    className={`text-xs ${
-                      voiceStatus.startsWith("Error")
-                        ? "text-red-400"
-                        : "text-green-400"
-                    }`}
-                  >
-                    {voiceStatus}
-                  </span>
-                )}
+              <div className="flex items-center gap-3 rounded-lg border border-purple-500/20 bg-purple-950/10 px-4 py-3">
+                <span className="rounded-full bg-purple-500/10 border border-purple-500/30 px-2.5 py-0.5 text-[10px] font-medium text-purple-400 uppercase tracking-wider">
+                  Coming Soon
+                </span>
+                <p className="text-xs text-muted-foreground">
+                  Voice cloning is on its way — your twin will speak in your voice.
+                </p>
               </div>
-              {profile.voice_id && (
-                <div className="rounded-md border border-green-500/20 bg-green-500/5 px-3 py-2">
-                  <p className="text-xs text-green-400">
-                    Voice sample configured. Your AI twin will use your cloned
-                    voice.
-                  </p>
-                </div>
-              )}
             </CardContent>
           </Card>
         </motion.div>

--- a/src/components/generate-widget.tsx
+++ b/src/components/generate-widget.tsx
@@ -538,6 +538,11 @@ export function GenerateWidget({ onCoworkOpen, placeholder }: GenerateWidgetProp
                 }}
                 disabled={videoLoading}
               />
+              {avatarFile && (
+                <p className="text-[11px] text-amber-400/80">
+                  ⏱ Videos with your photo take longer to generate than the default avatar.
+                </p>
+              )}
               <VideoPlayer
                 videoUrl={videoUrl}
                 videoLoading={videoLoading}


### PR DESCRIPTION
## Summary
- Fix video generation with user-uploaded photos: replaced async photo_avatar.create with direct talking_photo asset upload
- Photo uploaded as HeyGen asset and used immediately, no async polling needed
- Add UI hint that custom photo videos take longer than the default avatar
- Replace voice clone upload UI with a Coming Soon badge

## Test plan
- [ ] Upload a photo in the video widget, generate a video and confirm the photo is used instead of the default avatar
- [ ] Confirm timing hint appears when a photo is selected
- [ ] Confirm voice clone card shows Coming Soon badge with no upload button

Generated with [Claude Code](https://claude.com/claude-code)