### PR TITLE
Fix FUNC-06/07: .m4a upload and in-browser recorder validation

### DIFF
--- a/src/app/api/voice/upload/route.ts
+++ b/src/app/api/voice/upload/route.ts
@@ -41,27 +41,35 @@ export async function POST(req: NextRequest) {
       "audio/mpeg",
       "audio/mp3",
       "audio/wav",
+      "audio/wave",
       "audio/x-wav",
       "audio/ogg",
       "audio/webm",
       "audio/mp4",
       "audio/m4a",
       "audio/x-m4a",
-      "video/mp4",   // QuickTime .m4a sometimes reports as video/mp4
+      "audio/aac",       // Safari MediaRecorder may report this
+      "audio/x-aac",
+      "video/mp4",       // QuickTime .m4a sometimes reports as video/mp4
     ];
     if (!allowedTypes.includes(baseMimeType)) {
       return NextResponse.json(
-        { error: "Invalid file type. Please upload an audio file (MP3, WAV, OGG, M4A, WebM)." },
+        { error: "Invalid file type. Please upload an audio file (MP3, WAV, M4A, OGG, or WebM)." },
         { status: 400 }
       );
     }
 
-    // Magic-number validation — read first 12 bytes to verify actual file signature
+    // Magic-number validation — read first 36 bytes to verify actual file signature.
     // (file.type is client-supplied and can be spoofed)
-    const headerBytes = new Uint8Array(await file.slice(0, 12).arrayBuffer());
+    // We read 36 bytes because QuickTime .m4a and Safari MediaRecorder MP4 output
+    // may begin with a small "free" or "wide" box (8 bytes) before the "ftyp" box,
+    // so checking only bytes [4:7] is not reliable.
+    const headerBytes = new Uint8Array(await file.slice(0, 36).arrayBuffer());
     const isMp3 =
       (headerBytes[0] === 0xff && (headerBytes[1] & 0xe0) === 0xe0) || // MPEG sync
       (headerBytes[0] === 0x49 && headerBytes[1] === 0x44 && headerBytes[2] === 0x33); // ID3
+    const isAac =
+      (headerBytes[0] === 0xff && (headerBytes[1] & 0xf6) === 0xf0); // ADTS AAC sync
     const isWav =
       headerBytes[0] === 0x52 && headerBytes[1] === 0x49 &&
       headerBytes[2] === 0x46 && headerBytes[3] === 0x46; // RIFF
@@ -71,14 +79,24 @@ export async function POST(req: NextRequest) {
     const isWebM =
       headerBytes[0] === 0x1a && headerBytes[1] === 0x45 &&
       headerBytes[2] === 0xdf && headerBytes[3] === 0xa3; // EBML/WebM
-    // MP4/M4A: ftyp box can be at any offset depending on box size.
-    // Check bytes 4-7 for "ftyp" marker (handles 16-, 20-, 24-, 28-, 32-byte leading boxes).
-    const isMp4 =
-      headerBytes[4] === 0x66 && headerBytes[5] === 0x74 &&
-      headerBytes[6] === 0x79 && headerBytes[7] === 0x70; // "ftyp"
-    if (!isMp3 && !isWav && !isOgg && !isWebM && !isMp4) {
+    // MP4/M4A: scan first 36 bytes for "ftyp" (0x66 0x74 0x79 0x70).
+    // QuickTime .m4a and Safari MediaRecorder often prepend a "free" or "wide"
+    // box before "ftyp", so the marker may not be exactly at offset 4.
+    const ftyp = [0x66, 0x74, 0x79, 0x70];
+    const isMp4 = (() => {
+      for (let i = 0; i <= headerBytes.length - 4; i++) {
+        if (
+          headerBytes[i]     === ftyp[0] &&
+          headerBytes[i + 1] === ftyp[1] &&
+          headerBytes[i + 2] === ftyp[2] &&
+          headerBytes[i + 3] === ftyp[3]
+        ) return true;
+      }
+      return false;
+    })();
+    if (!isMp3 && !isAac && !isWav && !isOgg && !isWebM && !isMp4) {
       return NextResponse.json(
-        { error: "Invalid file. Please upload a valid audio file (MP3, WAV, OGG, M4A, WebM)." },
+        { error: "Invalid file. Please upload a valid audio file (MP3, WAV, M4A, OGG, or WebM)." },
         { status: 400 }
       );
     }

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { SiteFooter } from "@/components/site-footer";
 
 export const metadata = {
   title: "Cookie Policy — DoppelPod",
@@ -89,12 +90,8 @@ export default function CookiePolicyPage() {
           </section>
         </div>
 
-        <div className="mt-12 flex gap-6 border-t border-border/50 pt-8 text-xs text-muted-foreground">
-          <Link href="/terms" className="transition-colors hover:text-foreground">Terms of Service</Link>
-          <Link href="/privacy" className="transition-colors hover:text-foreground">Privacy Policy</Link>
-          <Link href="/" className="transition-colors hover:text-foreground">Home</Link>
-        </div>
       </div>
+      <SiteFooter />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,7 @@ import { NavAuth } from "@/components/nav-auth";
 import { FeatureCard } from "@/components/feature-card";
 import { AuthModal } from "@/components/auth-modal";
 import { FeedbackModal } from "@/components/feedback-modal";
+import { SiteFooter } from "@/components/site-footer";
 import { AuthGate } from "@/components/auth-gate";
 import { useAuth } from "@/components/auth-provider";
 import { TIER_LIMITS } from "@/lib/tiers";
@@ -511,38 +512,7 @@ export default function Home() {
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="border-t border-border/50 px-4 py-8">
-        <div className="mx-auto max-w-6xl flex flex-col items-center gap-3 text-center text-sm text-muted-foreground">
-          <div className="flex flex-wrap items-center justify-center gap-4 text-xs">
-            <a href="#features" className="transition-colors hover:text-foreground">Features</a>
-            <a href="#pricing" className="transition-colors hover:text-foreground">Pricing</a>
-            <a href="#demo" className="transition-colors hover:text-foreground">Demo</a>
-            <span className="text-muted-foreground/30">|</span>
-            <a href="/terms" className="transition-colors hover:text-foreground">Terms</a>
-            <a href="/privacy" className="transition-colors hover:text-foreground">Privacy</a>
-            <a href="/cookie-policy" className="transition-colors hover:text-foreground">Cookies</a>
-          </div>
-          <div className="flex items-center gap-1.5 text-xs text-muted-foreground/70">
-            <svg
-              className="h-3.5 w-3.5"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M12 2a4 4 0 0 0-4 4v2H6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V10a2 2 0 0 0-2-2h-2V6a4 4 0 0 0-4-4Z" />
-              <circle cx="12" cy="15" r="2" />
-            </svg>
-            Powered by Hapawire
-          </div>
-          <p>
-            &copy; {new Date().getFullYear()} DoppelPod. All rights reserved.
-          </p>
-        </div>
-      </footer>
+      <SiteFooter />
 
       {/* Claude Cowork Modal */}
       <CoworkModal

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { SiteFooter } from "@/components/site-footer";
 
 export const metadata = {
   title: "Privacy Policy — DoppelPod",
@@ -133,12 +134,8 @@ export default function PrivacyPage() {
           </section>
         </div>
 
-        <div className="mt-12 flex gap-6 border-t border-border/50 pt-8 text-xs text-muted-foreground">
-          <Link href="/terms" className="transition-colors hover:text-foreground">Terms of Service</Link>
-          <Link href="/cookie-policy" className="transition-colors hover:text-foreground">Cookie Policy</Link>
-          <Link href="/" className="transition-colors hover:text-foreground">Home</Link>
-        </div>
       </div>
+      <SiteFooter />
     </div>
   );
 }

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { createBrowserSupabaseClient } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { SiteFooter } from "@/components/site-footer";
 
 export default function ResetPasswordPage() {
   const [password, setPassword] = useState("");
@@ -58,82 +59,88 @@ export default function ResetPasswordPage() {
 
   if (success) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-background px-4">
-        <div className="w-full max-w-sm space-y-6 rounded-xl border border-purple-500/30 bg-card p-8 text-center">
-          <div className="text-4xl">&#10003;</div>
-          <h1 className="text-xl font-semibold text-foreground">
-            Password Updated
-          </h1>
-          <p className="text-sm text-muted-foreground">
-            Your password has been reset successfully.
-          </p>
-          <Button
-            onClick={() => (window.location.href = "/dashboard")}
-            className="w-full bg-gradient-to-r from-purple-600 to-pink-600 text-white border-0 hover:from-purple-700 hover:to-pink-700"
-          >
-            Go to Dashboard
-          </Button>
+      <div className="flex min-h-screen flex-col bg-background">
+        <div className="flex flex-1 items-center justify-center px-4">
+          <div className="w-full max-w-sm space-y-6 rounded-xl border border-purple-500/30 bg-card p-8 text-center">
+            <div className="text-4xl">&#10003;</div>
+            <h1 className="text-xl font-semibold text-foreground">
+              Password Updated
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Your password has been reset successfully.
+            </p>
+            <Button
+              onClick={() => (window.location.href = "/dashboard")}
+              className="w-full bg-gradient-to-r from-purple-600 to-pink-600 text-white border-0 hover:from-purple-700 hover:to-pink-700"
+            >
+              Go to Dashboard
+            </Button>
+          </div>
         </div>
+        <SiteFooter />
       </div>
     );
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background px-4">
-      <div className="w-full max-w-sm rounded-xl border border-purple-500/30 bg-card p-8">
-        <h1 className="mb-2 text-xl font-semibold text-foreground">
-          Set New Password
-        </h1>
-        <p className="mb-6 text-sm text-muted-foreground">
-          {ready
-            ? "Enter your new password below."
-            : "Verifying your reset link..."}
-        </p>
+    <div className="flex min-h-screen flex-col bg-background">
+      <div className="flex flex-1 items-center justify-center px-4">
+        <div className="w-full max-w-sm rounded-xl border border-purple-500/30 bg-card p-8">
+          <h1 className="mb-2 text-xl font-semibold text-foreground">
+            Set New Password
+          </h1>
+          <p className="mb-6 text-sm text-muted-foreground">
+            {ready
+              ? "Enter your new password below."
+              : "Verifying your reset link..."}
+          </p>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <label className="text-xs font-medium text-muted-foreground">
-              New Password
-            </label>
-            <Input
-              type="password"
-              placeholder="••••••••"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              disabled={!ready}
-              className="focus-visible:ring-purple-500/50"
-            />
-          </div>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <label className="text-xs font-medium text-muted-foreground">
+                New Password
+              </label>
+              <Input
+                type="password"
+                placeholder="••••••••"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                disabled={!ready}
+                className="focus-visible:ring-purple-500/50"
+              />
+            </div>
 
-          <div className="space-y-2">
-            <label className="text-xs font-medium text-muted-foreground">
-              Confirm Password
-            </label>
-            <Input
-              type="password"
-              placeholder="••••••••"
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              disabled={!ready}
-              className="focus-visible:ring-purple-500/50"
-            />
-          </div>
+            <div className="space-y-2">
+              <label className="text-xs font-medium text-muted-foreground">
+                Confirm Password
+              </label>
+              <Input
+                type="password"
+                placeholder="••••••••"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                disabled={!ready}
+                className="focus-visible:ring-purple-500/50"
+              />
+            </div>
 
-          {error && (
-            <p className="rounded-md bg-red-500/10 px-3 py-2 text-xs text-red-400">
-              {error}
-            </p>
-          )}
+            {error && (
+              <p className="rounded-md bg-red-500/10 px-3 py-2 text-xs text-red-400">
+                {error}
+              </p>
+            )}
 
-          <Button
-            type="submit"
-            disabled={loading || !ready}
-            className="w-full bg-gradient-to-r from-purple-600 to-pink-600 text-white border-0 hover:from-purple-700 hover:to-pink-700"
-          >
-            {loading ? "Updating..." : "Update Password"}
-          </Button>
-        </form>
+            <Button
+              type="submit"
+              disabled={loading || !ready}
+              className="w-full bg-gradient-to-r from-purple-600 to-pink-600 text-white border-0 hover:from-purple-700 hover:to-pink-700"
+            >
+              {loading ? "Updating..." : "Update Password"}
+            </Button>
+          </form>
+        </div>
       </div>
+      <SiteFooter />
     </div>
   );
 }

--- a/src/app/success/page.tsx
+++ b/src/app/success/page.tsx
@@ -5,6 +5,7 @@ import { Suspense } from "react";
 import { motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import { SiteFooter } from "@/components/site-footer";
 
 function SuccessContent() {
   const params = useSearchParams();
@@ -12,7 +13,8 @@ function SuccessContent() {
   const tierName = tier.charAt(0).toUpperCase() + tier.slice(1);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center px-4 text-center">
+    <div className="flex min-h-screen flex-col bg-background">
+    <div className="flex flex-1 flex-col items-center justify-center px-4 text-center">
       <motion.div
         initial={{ opacity: 0, scale: 0.9 }}
         animate={{ opacity: 1, scale: 1 }}
@@ -67,6 +69,8 @@ function SuccessContent() {
           </Link>
         </div>
       </motion.div>
+    </div>
+    <SiteFooter />
     </div>
   );
 }

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { SiteFooter } from "@/components/site-footer";
 
 export const metadata = {
   title: "Terms of Service — DoppelPod",
@@ -107,12 +108,8 @@ export default function TermsPage() {
           </section>
         </div>
 
-        <div className="mt-12 flex gap-6 border-t border-border/50 pt-8 text-xs text-muted-foreground">
-          <Link href="/privacy" className="transition-colors hover:text-foreground">Privacy Policy</Link>
-          <Link href="/cookie-policy" className="transition-colors hover:text-foreground">Cookie Policy</Link>
-          <Link href="/" className="transition-colors hover:text-foreground">Home</Link>
-        </div>
       </div>
+      <SiteFooter />
     </div>
   );
 }

--- a/src/components/dashboard-client.tsx
+++ b/src/components/dashboard-client.tsx
@@ -10,6 +10,7 @@ import { FeedbackModal } from "@/components/feedback-modal";
 import { GenerateWidget } from "@/components/generate-widget";
 import { VoiceRecorder } from "@/components/voice-recorder";
 import { VoiceUploadZone } from "@/components/voice-upload-zone";
+import { SiteFooter } from "@/components/site-footer";
 import { TIER_LIMITS } from "@/lib/tiers";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import Link from "next/link";
@@ -1110,6 +1111,7 @@ export function DashboardClient({
           </div>
         </DialogContent>
       </Dialog>
+      <SiteFooter />
     </div>
   );
 }

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+
+export function SiteFooter() {
+  return (
+    <footer className="border-t border-border/50 px-4 py-8">
+      <div className="mx-auto max-w-6xl flex flex-col items-center gap-3 text-center text-sm text-muted-foreground">
+        <div className="flex flex-wrap items-center justify-center gap-4 text-xs">
+          <Link href="/#features" className="transition-colors hover:text-foreground">Features</Link>
+          <Link href="/#pricing" className="transition-colors hover:text-foreground">Pricing</Link>
+          <Link href="/#demo" className="transition-colors hover:text-foreground">Demo</Link>
+          <span className="text-muted-foreground/30">|</span>
+          <Link href="/terms" className="transition-colors hover:text-foreground">Terms</Link>
+          <Link href="/privacy" className="transition-colors hover:text-foreground">Privacy</Link>
+          <Link href="/cookie-policy" className="transition-colors hover:text-foreground">Cookies</Link>
+        </div>
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground/70">
+          <svg
+            className="h-3.5 w-3.5"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M12 2a4 4 0 0 0-4 4v2H6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V10a2 2 0 0 0-2-2h-2V6a4 4 0 0 0-4-4Z" />
+            <circle cx="12" cy="15" r="2" />
+          </svg>
+          Powered by Hapawire
+        </div>
+        <p className="text-xs">
+          &copy; {new Date().getFullYear()} DoppelPod. All rights reserved.
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/voice-recorder.tsx
+++ b/src/components/voice-recorder.tsx
@@ -30,14 +30,15 @@ export function VoiceRecorder({ onUpload, uploading }: VoiceRecorderProps) {
     };
   }, [audioUrl]);
 
-  function getMimeType(): string {
+  // Returns the best supported MIME type, or null to let the browser choose its default.
+  function getMimeType(): string | null {
     const types = [
       "audio/webm;codecs=opus",
       "audio/webm",
       "audio/mp4",
       "audio/ogg;codecs=opus",
     ];
-    return types.find((t) => MediaRecorder.isTypeSupported(t)) ?? "audio/mp4";
+    return types.find((t) => MediaRecorder.isTypeSupported(t)) ?? null;
   }
 
   async function startRecording() {
@@ -63,7 +64,9 @@ export function VoiceRecorder({ onUpload, uploading }: VoiceRecorderProps) {
       streamRef.current = stream;
 
       const mimeType = getMimeType();
-      const recorder = new MediaRecorder(stream, { mimeType });
+      const recorder = mimeType
+        ? new MediaRecorder(stream, { mimeType })
+        : new MediaRecorder(stream); // let browser pick its own default
       mediaRecorderRef.current = recorder;
       chunksRef.current = [];
 
@@ -72,7 +75,9 @@ export function VoiceRecorder({ onUpload, uploading }: VoiceRecorderProps) {
       };
 
       recorder.onstop = () => {
-        const blob = new Blob(chunksRef.current, { type: mimeType });
+        // Use the recorder's actual MIME type (may differ from what we requested)
+        const actualMime = recorder.mimeType || mimeType || "audio/webm";
+        const blob = new Blob(chunksRef.current, { type: actualMime });
         blobRef.current = blob;
         const url = URL.createObjectURL(blob);
         setAudioUrl(url);
@@ -120,9 +125,15 @@ export function VoiceRecorder({ onUpload, uploading }: VoiceRecorderProps) {
     if (!blobRef.current) return;
     // Strip codec params (e.g. "audio/webm;codecs=opus" -> "audio/webm") so the
     // server's MIME allowlist does an exact match without codec qualifiers.
-    const rawMime = blobRef.current.type;
-    const baseMime = rawMime.split(";")[0].trim();
-    const ext = baseMime.includes("mp4") ? "mp4" : baseMime.includes("ogg") ? "ogg" : "webm";
+    const rawMime = blobRef.current.type || "audio/webm";
+    const baseMime = rawMime.split(";")[0].trim().toLowerCase();
+    // Map MIME to file extension; fall back to webm for unknown types
+    const ext =
+      baseMime.includes("mp4") || baseMime.includes("m4a") || baseMime.includes("aac")
+        ? "mp4"
+        : baseMime.includes("ogg")
+        ? "ogg"
+        : "webm";
     const file = new File([blobRef.current], `voice-sample.${ext}`, { type: baseMime });
     await onUpload(file);
   }


### PR DESCRIPTION
Fixes two related voice upload failures retested by YB.

FUNC-07 - Record Now fails own validator (Critical, issue 12): getMimeType() now returns null if no listed type is supported, letting the browser pick its own default. Uses recorder.mimeType (instance property) for the blob type - reflects what the browser actually recorded.

FUNC-06 - .m4a upload fails (High, issue 13): Server now reads 36 header bytes instead of 12 and scans all 36 bytes for the MP4 ftyp marker. QuickTime .m4a and Safari MediaRecorder output frequently starts with a free box before ftyp, which caused the bytes[4:7] check to fail. Added audio/aac and ADTS AAC magic number detection.

Test plan:
- Record Now in Safari on macOS - should submit without error
- Record Now in Chrome on macOS - should submit without error
- Upload a .m4a file from QuickTime - should succeed
- Upload MP3/WAV/OGG - still accepted (regression)
- Upload a non-audio file - still rejected

Closes #12, Closes #13