### PR TITLE
Fix login flicker — loading must not drop until profile is ready

### DIFF
--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -70,21 +70,28 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, [fetchProfile]);
 
   useEffect(() => {
-    supabase.auth.getUser().then(({ data: { user } }) => {
+    // getUser() is the sole owner of initial loading state.
+    // loading stays true until the profile is in hand — prevents "expired" flash.
+    supabase.auth.getUser().then(async ({ data: { user } }) => {
       setUser(user);
+      if (user) await fetchProfile();
       setLoading(false);
-      if (user) fetchProfile();
     });
 
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
+    } = supabase.auth.onAuthStateChange(async (event, session) => {
+      // INITIAL_SESSION is already handled by getUser() above — skip to avoid double work.
+      if (event === "INITIAL_SESSION") return;
+
       const newUser = session?.user ?? null;
       setUser(newUser);
-      setLoading(false);
+
       if (newUser) {
-        // Small delay to allow trigger to create profile on signup
-        setTimeout(fetchProfile, 500);
+        // Raise loading so effectiveTier shows "trial" (not "expired") while profile fetches.
+        setLoading(true);
+        await fetchProfile();
+        setLoading(false);
       } else {
         setProfile(null);
         setUsage(null);


### PR DESCRIPTION
Closes #29

## Root cause
Two separate code paths both called \setLoading(false)\ before the profile was fetched:

1. \getUser()\ set loading=false, then fired fetchProfile — window of \loading=false, profile=null\ → effectiveTier='expired'
2. \onAuthStateChange\ set loading=false immediately, then called \setTimeout(fetchProfile, 500)\ — 500ms guaranteed expired window on every login

## Fix
- \getUser()\ now awaits fetchProfile before setLoading(false)
- \onAuthStateChange\ skips INITIAL_SESSION entirely (handled by getUser)
- On SIGNED_IN: raises loading=true → awaits fetchProfile → drops loading=false
- 500ms setTimeout removed — no more artificial expired window

effectiveTier now shows 'trial' during every profile fetch, never 'expired'.