### PR TITLE
Move dashboard nav links into top navbar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -116,6 +116,84 @@
   --sidebar-ring: oklch(0.556 0 0);
 }
 
+/* ── Aurora background ─────────────────────────────────────── */
+.aurora-layer {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.aurora-blob {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(70px);
+  opacity: 0.45;
+  mix-blend-mode: screen;
+}
+
+.aurora-blob-1 {
+  width: 60vw; height: 50vh;
+  background: radial-gradient(ellipse, #a855f7 0%, transparent 70%);
+  top: -15%; left: -10%;
+  animation: aurora-drift-1 18s ease-in-out infinite alternate;
+}
+.aurora-blob-2 {
+  width: 50vw; height: 45vh;
+  background: radial-gradient(ellipse, #ec4899 0%, transparent 70%);
+  top: -20%; right: -5%;
+  animation: aurora-drift-2 22s ease-in-out infinite alternate;
+}
+.aurora-blob-3 {
+  width: 40vw; height: 40vh;
+  background: radial-gradient(ellipse, #6366f1 0%, transparent 70%);
+  top: 10%; left: 30%;
+  animation: aurora-drift-3 26s ease-in-out infinite alternate;
+}
+.aurora-blob-4 {
+  width: 35vw; height: 30vh;
+  background: radial-gradient(ellipse, #f472b6 0%, transparent 70%);
+  top: 5%; right: 20%;
+  animation: aurora-drift-4 20s ease-in-out infinite alternate;
+}
+
+.aurora-fade {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    transparent 40%,
+    var(--background) 75%
+  );
+}
+
+@keyframes aurora-drift-1 {
+  0%   { transform: translate(0, 0) scale(1); }
+  33%  { transform: translate(8vw, 6vh) scale(1.1); }
+  66%  { transform: translate(-4vw, 10vh) scale(0.95); }
+  100% { transform: translate(12vw, 4vh) scale(1.05); }
+}
+@keyframes aurora-drift-2 {
+  0%   { transform: translate(0, 0) scale(1); }
+  33%  { transform: translate(-10vw, 8vh) scale(1.08); }
+  66%  { transform: translate(5vw, 14vh) scale(0.92); }
+  100% { transform: translate(-8vw, 6vh) scale(1.1); }
+}
+@keyframes aurora-drift-3 {
+  0%   { transform: translate(0, 0) scale(1); }
+  50%  { transform: translate(-6vw, 8vh) scale(1.15); }
+  100% { transform: translate(6vw, -4vh) scale(0.9); }
+}
+@keyframes aurora-drift-4 {
+  0%   { transform: translate(0, 0) scale(1); }
+  50%  { transform: translate(8vw, 10vh) scale(1.2); }
+  100% { transform: translate(-4vw, 6vh) scale(0.85); }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/src/components/dashboard-client.tsx
+++ b/src/components/dashboard-client.tsx
@@ -407,35 +407,6 @@ export function DashboardClient({
   return (
     <div className="min-h-screen bg-background text-foreground">
       {/* Nav */}
-      <nav className="fixed top-0 z-50 w-full border-b border-border/50 bg-background/80 backdrop-blur-lg">
-        <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
-          <div className="flex items-center gap-3">
-            {/* Hamburger — mobile only */}
-            <button
-              onClick={() => setMobileNavOpen(true)}
-              className="lg:hidden flex flex-col justify-center gap-1.5 p-1 text-muted-foreground hover:text-foreground transition-colors"
-              aria-label="Open navigation"
-            >
-              <span className="block h-0.5 w-5 bg-current" />
-              <span className="block h-0.5 w-5 bg-current" />
-              <span className="block h-0.5 w-5 bg-current" />
-            </button>
-            <Link
-              href="/"
-              className="bg-gradient-to-r from-purple-400 to-pink-500 bg-clip-text text-lg font-bold text-transparent"
-            >
-              DoppelPod
-            </Link>
-          </div>
-          <div className="flex items-center gap-4">
-            <span className="text-sm text-muted-foreground hidden sm:inline">
-              {user.email}
-            </span>
-          </div>
-        </div>
-      </nav>
-
-      {/* Nav links — desktop sidebar + mobile drawer */}
       {(() => {
         const navLinks = [
           { label: "Account",          href: "#account" },
@@ -446,23 +417,54 @@ export function DashboardClient({
         ];
         return (
           <>
-            {/* Desktop sidebar — fixed left, lg+ only */}
-            <nav className="hidden lg:flex fixed left-6 top-1/2 -translate-y-1/2 z-40 flex-col gap-1">
-              {navLinks.map(({ label, href }) => (
-                <a
-                  key={href}
-                  href={href}
-                  className="text-xs text-muted-foreground/60 hover:text-purple-400 transition-colors py-0.5 whitespace-nowrap"
-                >
-                  {label}
-                </a>
-              ))}
-              <button
-                onClick={() => signOut()}
-                className="text-xs text-red-400/70 hover:text-red-300 transition-colors text-left pt-2 mt-1 border-t border-border/20"
-              >
-                Logout
-              </button>
+            {/* Top nav bar */}
+            <nav className="fixed top-0 z-50 w-full border-b border-border/50 bg-background/80 backdrop-blur-lg">
+              <div className="relative mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
+                <div className="flex items-center gap-3">
+                  {/* Hamburger — mobile only */}
+                  <button
+                    onClick={() => setMobileNavOpen(true)}
+                    className="lg:hidden flex flex-col justify-center gap-1.5 p-1 text-muted-foreground hover:text-foreground transition-colors"
+                    aria-label="Open navigation"
+                  >
+                    <span className="block h-0.5 w-5 bg-current" />
+                    <span className="block h-0.5 w-5 bg-current" />
+                    <span className="block h-0.5 w-5 bg-current" />
+                  </button>
+                  <Link
+                    href="/"
+                    className="bg-gradient-to-r from-purple-400 to-pink-500 bg-clip-text text-lg font-bold text-transparent"
+                  >
+                    DoppelPod
+                  </Link>
+                </div>
+
+                {/* Nav links — centered, desktop only */}
+                <div className="hidden lg:flex absolute left-1/2 -translate-x-1/2 items-center gap-6">
+                  <span className="text-sm text-muted-foreground/60 uppercase tracking-wider whitespace-nowrap">Navigation:</span>
+                  {navLinks.map(({ label, href }) => (
+                    <a
+                      key={href}
+                      href={href}
+                      className="text-sm text-pink-500 hover:text-pink-400 transition-colors whitespace-nowrap"
+                    >
+                      {label}
+                    </a>
+                  ))}
+                </div>
+
+                <div className="flex items-center gap-4">
+                  <span className="text-sm text-muted-foreground hidden sm:inline">
+                    {user.email}
+                  </span>
+                  <button
+                    onClick={() => signOut()}
+                    className="hidden lg:inline text-xs text-red-400/70 hover:text-red-300 transition-colors whitespace-nowrap cursor-pointer"
+                  >
+                    Logout
+                  </button>
+                </div>
+              </div>
             </nav>
 
             {/* Mobile drawer */}
@@ -497,7 +499,7 @@ export function DashboardClient({
                   ))}
                   <button
                     onClick={() => { setMobileNavOpen(false); signOut(); }}
-                    className="text-sm text-red-400 hover:text-red-300 transition-colors text-left pt-1.5 mt-1 border-t border-border/20"
+                    className="text-sm text-red-400 hover:text-red-300 transition-colors text-left pt-1.5 mt-1 border-t border-border/20 cursor-pointer"
                   >
                     Logout
                   </button>


### PR DESCRIPTION
﻿Replaces the fixed left sidebar with centered nav links in the top navbar on desktop. Navigation: label in muted grey, section links in DoppelPod pink, logout in red on the right with pointer cursor. Mobile hamburger drawer unchanged.
